### PR TITLE
allow domains which are not running to parse correctly

### DIFF
--- a/kvm_extensions.rb
+++ b/kvm_extensions.rb
@@ -17,9 +17,14 @@ if not virtualization.nil? and virtualization[:system] == 'kvm'
       virtualization[:kvm][:guests][name][:id] = id.strip
       virtualization[:kvm][:guests][name][:state] = state.strip
       # Let's parse dominfo for more guest information
-      %x{virsh dominfo #{id} | grep -v 'Id:'}.each_line do |l|
+      if "#{id}" == "-"
+        domains = %x{virsh dominfo #{name} | grep -v 'Id:'}
+      else
+        domains = %x{virsh dominfo #{id} | grep -v 'Id:'}
+      end
+       domains.each_line do |l|
         k, v = l.split(":")
-        virtualization[:kvm][:guests][name][k.strip] = v.strip unless v.nil?
+        virtualization[:kvm][:guests][name][k.strip] = v.strip unless v.nil? 
         case k.strip
         when 'CPU(s)'
           guest_cpu_total += v.strip.to_i
@@ -37,4 +42,3 @@ if not virtualization.nil? and virtualization[:system] == 'kvm'
 
   end
 end
-


### PR DESCRIPTION
So we use VM templates with KVM, and the currently plugins spits error message about not being able to 'display dominfo for "-"`  (Shutdown VM's dont have an ID)  this is a very simple little addition that will do a virsh dominfo <name> in the event that the VM is in a shutdown state.
