### PR TITLE
Gather host hardware details

### DIFF
--- a/kvm_extensions.rb
+++ b/kvm_extensions.rb
@@ -44,6 +44,11 @@ if not virtualization.nil? and virtualization[:system] == 'kvm'
       k,v = detail.split ":"
       virtualization[:kvm][:hardware][k.strip] = v.strip unless v.nil?
     end
+    %x{virsh freecell}.each_line do |detail|
+      k,v = detail.split ":"
+      virtualization[:kvm][:hardware][:freecell] = v.strip unless v.nil?
+    end
+
   elsif virtualization[:role] == 'guest'
 
 


### PR DESCRIPTION
this patch adds the hardware info (provided by `virsh nodeinfo`) of the host under the virtualization:kvm:hardware key. We use this to easily get an overview of what the host looks like without having to collect, calculate and summarize all the other hardware attributes in ohai.
